### PR TITLE
Clean up links, scripts and names

### DIFF
--- a/devices/common_patches/gd32f130_150.yaml
+++ b/devices/common_patches/gd32f130_150.yaml
@@ -1,0 +1,28 @@
+# Copyright 2021 The gd32-rs authors.
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+# Patches for both GD31F130 and GD32F150.
+
+ADC:
+  CTL0:
+    _delete:
+      - DRES
+  _delete:
+    - OVSAMPCTL
+
+DBG:
+  CTL0:
+    _delete:
+      - "CAN?_HOLD"
+
+"I2C?":
+  _delete:
+    - SAMCS
+
+"TIMER[0-2],TIMER1[3-6]":
+  _delete:
+    - CFG
+
+_delete:
+  - "CAN?"

--- a/devices/common_patches/gd32f1x0.yaml
+++ b/devices/common_patches/gd32f1x0.yaml
@@ -8,6 +8,11 @@ TIMER0:
     _modify:
       SCM1:
         name: "SMC1"
+"TIMER[1-2]":
+  SWEVG:
+    _delete:
+      - BRKG
+
 FMC:
   STAT:
     _modify:

--- a/devices/gd32f130.yaml
+++ b/devices/gd32f130.yaml
@@ -4,6 +4,9 @@
 
 _svd: ../svd/gd32f130.svd
 
+_modify:
+  name: "GD32F130"
+
 _include:
   - common_patches/gd32f1x0.yaml
   - ../peripherals/adc/adc.yaml

--- a/devices/gd32f130.yaml
+++ b/devices/gd32f130.yaml
@@ -7,8 +7,12 @@ _svd: ../svd/gd32f130.svd
 _modify:
   name: "GD32F130"
 
+_delete:
+  - DAC
+
 _include:
   - common_patches/gd32f1x0.yaml
+  - common_patches/gd32f130_150.yaml
   - ../peripherals/adc/adc.yaml
   - ../peripherals/crc/crc.yaml
   - ../peripherals/cmp/cmp.yaml

--- a/devices/gd32f150.yaml
+++ b/devices/gd32f150.yaml
@@ -4,6 +4,9 @@
 
 _svd: ../svd/gd32f150.svd
 
+_modify:
+  name: "GD32F150"
+
 _include:
   - common_patches/gd32f1x0.yaml
   - ../peripherals/adc/adc.yaml

--- a/devices/gd32f150.yaml
+++ b/devices/gd32f150.yaml
@@ -7,8 +7,23 @@ _svd: ../svd/gd32f150.svd
 _modify:
   name: "GD32F150"
 
+DAC:
+  CTL:
+    _delete:
+      - "*1"
+  SWT:
+    _delete:
+      - SWTR1
+  STAT:
+    _delete:
+      - DDUDR1
+  _delete:
+    - "DAC1*"
+    - "DACC*"
+
 _include:
   - common_patches/gd32f1x0.yaml
+  - common_patches/gd32f130_150.yaml
   - ../peripherals/adc/adc.yaml
   - ../peripherals/crc/crc.yaml
   - ../peripherals/cmp/cmp.yaml

--- a/devices/gd32f170.yaml
+++ b/devices/gd32f170.yaml
@@ -4,6 +4,9 @@
 
 _svd: ../svd/gd32f170.svd
 
+_modify:
+  name: "GD32F170"
+
 _include:
   - common_patches/gd32f1x0.yaml
   - common_patches/gd32f170_190.yaml

--- a/devices/gd32f170.yaml
+++ b/devices/gd32f170.yaml
@@ -7,6 +7,9 @@ _svd: ../svd/gd32f170.svd
 _modify:
   name: "GD32F170"
 
+_delete:
+  - DAC
+
 _include:
   - common_patches/gd32f1x0.yaml
   - common_patches/gd32f170_190.yaml

--- a/devices/gd32f190.yaml
+++ b/devices/gd32f190.yaml
@@ -4,6 +4,9 @@
 
 _svd: ../svd/gd32f190.svd
 
+_modify:
+  name: "GD32F190"
+
 _include:
   - common_patches/gd32f1x0.yaml
   - common_patches/gd32f170_190.yaml

--- a/gd32_part_table.yaml
+++ b/gd32_part_table.yaml
@@ -16,28 +16,28 @@
 
 gd32f1:
   gd32f130:
-    url: https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m3/value-line/
+    url: https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m3/value-line/gd32f130-series/
     rm: GD32F1x0
     rm_title: GD32F1x0
     rm_url: https://www.gigadevice.com/manual/gd32f190xxxx-user-manual/
     members:
       - GD32F130
   gd32f150:
-    url: https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m3/value-line/
+    url: https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m3/value-line/gd32f150-series/
     rm: GD32F1x0
     rm_title: GD32F1x0
     rm_url: https://www.gigadevice.com/manual/gd32f190xxxx-user-manual/
     members:
       - GD32F150
   gd32f170:
-    url: https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m3/value-line/
+    url: https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m3/value-line/gd32f170-series/
     rm: GD32F1x0
     rm_title: GD32F1x0
     rm_url: https://www.gigadevice.com/manual/gd32f190xxxx-user-manual/
     members:
       - GD32F170
   gd32f190:
-    url: https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m3/value-line/
+    url: https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m3/value-line/gd32f190-series/
     rm: GD32F1x0
     rm_title: GD32F1x0
     rm_url: https://www.gigadevice.com/manual/gd32f190xxxx-user-manual/

--- a/scripts/htmlcomparesvdall.sh
+++ b/scripts/htmlcomparesvdall.sh
@@ -4,15 +4,8 @@ set -euxo pipefail
 mkdir html
 
 mkdir html/gd32f
-python3 scripts/htmlcomparesvd.py svd/gd32f{130,170}.svd.patched
-sed -i 's#<table>#<p>Only a representative member of each family included; click to view entire family</p><table>#' html/index.html
-sed -i 's#gd32f130#<a href="gd32f1/index.html">GD32F130</a>#' html/index.html
-sed -i 's#gd32f170#<a href="gd32f1/index.html">GD32F170</a>#' html/index.html
+python3 scripts/htmlcomparesvd.py svd/gd32f*.svd.patched
 mv html/*.html html/gd32f
-
-mkdir html/gd32f/gd32f1
-python3 scripts/htmlcomparesvd.py svd/gd32f1*.svd.patched
-mv html/*.html html/gd32f/gd32f1
 
 cat > html/index.html <<EOF
 <!DOCTYPE html>


### PR DESCRIPTION
Also removes peripherals and fields that don't actually exist on each variant.