### PR TITLE
Fix typo in CEN derivedFrom.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+- GD32F1x0
+  - Fixed `TIMERn.CTL0.CEN` values, the enum values were accidentally reversed in 0.3.0.
+
 ## [0.3.0]
 
 - GD32F1x0

--- a/peripherals/timer/timer_basic.yaml
+++ b/peripherals/timer/timer_basic.yaml
@@ -44,7 +44,7 @@ TIMER0:
     UPDIS:
       _derivedFrom: "TIMER0.CTL0.UPDIS.UPDIS"
     CEN:
-      _derivedFrom: "TIMER0.CTL0.UPDIS.UPDIS"
+      _derivedFrom: "TIMER0.CTL0.CEN.CEN"
   DMAINTEN:
     UPIE:
       _derivedFrom: "TIMER0.DMAINTEN.UPIE.UPIE"


### PR DESCRIPTION
This was causing the enum values to be the opposite of what they should have been.