### PR TITLE
Add low-hanging fruit peripherals for GD32E23x devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [unreleased]
+
+- GD32F1x0
+  - Renamed `I2Cn.STAT0.SMBALTS` to `SMBALT`. This matches what the documentation calls it.
+
 ## [0.4.0]
 
 - GD32F1x0

--- a/devices/common_patches/gd32e23x.yaml
+++ b/devices/common_patches/gd32e23x.yaml
@@ -25,3 +25,9 @@ FMC:
   _modify:
     CPCPOLY:
       name: "CRCPOLY"
+
+"TIMER*":
+  CAR:
+    _modify:
+      CARL:
+        name: "CAR"

--- a/devices/common_patches/gd32e23x.yaml
+++ b/devices/common_patches/gd32e23x.yaml
@@ -31,3 +31,11 @@ FMC:
     _modify:
       CARL:
         name: "CAR"
+
+"USART*":
+  BAUD:
+    _modify:
+      BRR_INT:
+        name: "INTDIV"
+      BRR_FRA:
+        name: "FRADIV"

--- a/devices/common_patches/gd32e23x.yaml
+++ b/devices/common_patches/gd32e23x.yaml
@@ -7,3 +7,16 @@ RCU:
     _modify:
       KEY:
         access: write-only
+
+# Rename FMC fields to match GD32F1x0 devices.
+FMC:
+  OBSTAT:
+    _modify:
+      DATA:
+        name: "OB_DATA"
+      USER:
+        name: "OB_USER"
+  WP:
+    _modify:
+      WP:
+        name: "OB_WP"

--- a/devices/common_patches/gd32e23x.yaml
+++ b/devices/common_patches/gd32e23x.yaml
@@ -20,3 +20,8 @@ FMC:
     _modify:
       WP:
         name: "OB_WP"
+
+"SPI?":
+  _modify:
+    CPCPOLY:
+      name: "CRCPOLY"

--- a/devices/common_patches/gd32f1x0.yaml
+++ b/devices/common_patches/gd32f1x0.yaml
@@ -50,6 +50,8 @@ TIMER15:
     _modify:
       BE:
         name: "BERR"
+      SMBALTS:
+        name: "SMBALT"
   STAT1:
     _modify:
       ECV:

--- a/devices/gd32e230.yaml
+++ b/devices/gd32e230.yaml
@@ -10,3 +10,4 @@ _include:
   - ../peripherals/cmp/cmp.yaml
   - ../peripherals/crc/crc.yaml
   - ../peripherals/exti/exti.yaml
+  - ../peripherals/flash/flash.yaml

--- a/devices/gd32e230.yaml
+++ b/devices/gd32e230.yaml
@@ -20,3 +20,4 @@ _include:
   - ../peripherals/syscfg/syscfg.yaml
   - ../peripherals/syscfg/syscfg_hcce.yaml
   - ../peripherals/usart/usart.yaml
+  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/gd32e230.yaml
+++ b/devices/gd32e230.yaml
@@ -11,3 +11,5 @@ _include:
   - ../peripherals/crc/crc.yaml
   - ../peripherals/exti/exti.yaml
   - ../peripherals/flash/flash.yaml
+  - ../peripherals/fwdgt/fwdgt.yaml
+  - ../peripherals/gpio/gpio.yaml

--- a/devices/gd32e230.yaml
+++ b/devices/gd32e230.yaml
@@ -15,3 +15,5 @@ _include:
   - ../peripherals/gpio/gpio.yaml
   - ../peripherals/i2c/i2c.yaml
   - ../peripherals/i2c/i2c_high.yaml
+  - ../peripherals/pmu/pmu.yaml
+  - ../peripherals/pmu/pmu_wupen1.yaml

--- a/devices/gd32e230.yaml
+++ b/devices/gd32e230.yaml
@@ -7,3 +7,4 @@ _svd: ../svd/gd32e230.svd
 _include:
   - common_patches/gd32e23x.yaml
   - ../peripherals/adc/adc.yaml
+  - ../peripherals/cmp/cmp.yaml

--- a/devices/gd32e230.yaml
+++ b/devices/gd32e230.yaml
@@ -13,3 +13,5 @@ _include:
   - ../peripherals/flash/flash.yaml
   - ../peripherals/fwdgt/fwdgt.yaml
   - ../peripherals/gpio/gpio.yaml
+  - ../peripherals/i2c/i2c.yaml
+  - ../peripherals/i2c/i2c_high.yaml

--- a/devices/gd32e230.yaml
+++ b/devices/gd32e230.yaml
@@ -8,3 +8,5 @@ _include:
   - common_patches/gd32e23x.yaml
   - ../peripherals/adc/adc.yaml
   - ../peripherals/cmp/cmp.yaml
+  - ../peripherals/crc/crc.yaml
+  - ../peripherals/exti/exti.yaml

--- a/devices/gd32e230.yaml
+++ b/devices/gd32e230.yaml
@@ -19,3 +19,4 @@ _include:
   - ../peripherals/pmu/pmu_wupen1.yaml
   - ../peripherals/syscfg/syscfg.yaml
   - ../peripherals/syscfg/syscfg_hcce.yaml
+  - ../peripherals/usart/usart.yaml

--- a/devices/gd32e230.yaml
+++ b/devices/gd32e230.yaml
@@ -17,3 +17,5 @@ _include:
   - ../peripherals/i2c/i2c_high.yaml
   - ../peripherals/pmu/pmu.yaml
   - ../peripherals/pmu/pmu_wupen1.yaml
+  - ../peripherals/syscfg/syscfg.yaml
+  - ../peripherals/syscfg/syscfg_hcce.yaml

--- a/devices/gd32e230.yaml
+++ b/devices/gd32e230.yaml
@@ -6,3 +6,4 @@ _svd: ../svd/gd32e230.svd
 
 _include:
   - common_patches/gd32e23x.yaml
+  - ../peripherals/adc/adc.yaml

--- a/devices/gd32e231.yaml
+++ b/devices/gd32e231.yaml
@@ -10,3 +10,4 @@ _include:
   - ../peripherals/cmp/cmp.yaml
   - ../peripherals/crc/crc.yaml
   - ../peripherals/exti/exti.yaml
+  - ../peripherals/flash/flash.yaml

--- a/devices/gd32e231.yaml
+++ b/devices/gd32e231.yaml
@@ -17,3 +17,4 @@ _include:
   - ../peripherals/i2c/i2c_high.yaml
   - ../peripherals/pmu/pmu.yaml
   - ../peripherals/syscfg/syscfg.yaml
+  - ../peripherals/usart/usart.yaml

--- a/devices/gd32e231.yaml
+++ b/devices/gd32e231.yaml
@@ -11,3 +11,5 @@ _include:
   - ../peripherals/crc/crc.yaml
   - ../peripherals/exti/exti.yaml
   - ../peripherals/flash/flash.yaml
+  - ../peripherals/fwdgt/fwdgt.yaml
+  - ../peripherals/gpio/gpio.yaml

--- a/devices/gd32e231.yaml
+++ b/devices/gd32e231.yaml
@@ -16,3 +16,4 @@ _include:
   - ../peripherals/i2c/i2c.yaml
   - ../peripherals/i2c/i2c_high.yaml
   - ../peripherals/pmu/pmu.yaml
+  - ../peripherals/syscfg/syscfg.yaml

--- a/devices/gd32e231.yaml
+++ b/devices/gd32e231.yaml
@@ -6,3 +6,4 @@ _svd: ../svd/gd32e231.svd
 
 _include:
   - common_patches/gd32e23x.yaml
+  - ../peripherals/adc/adc.yaml

--- a/devices/gd32e231.yaml
+++ b/devices/gd32e231.yaml
@@ -13,3 +13,5 @@ _include:
   - ../peripherals/flash/flash.yaml
   - ../peripherals/fwdgt/fwdgt.yaml
   - ../peripherals/gpio/gpio.yaml
+  - ../peripherals/i2c/i2c.yaml
+  - ../peripherals/i2c/i2c_high.yaml

--- a/devices/gd32e231.yaml
+++ b/devices/gd32e231.yaml
@@ -7,3 +7,4 @@ _svd: ../svd/gd32e231.svd
 _include:
   - common_patches/gd32e23x.yaml
   - ../peripherals/adc/adc.yaml
+  - ../peripherals/cmp/cmp.yaml

--- a/devices/gd32e231.yaml
+++ b/devices/gd32e231.yaml
@@ -8,3 +8,5 @@ _include:
   - common_patches/gd32e23x.yaml
   - ../peripherals/adc/adc.yaml
   - ../peripherals/cmp/cmp.yaml
+  - ../peripherals/crc/crc.yaml
+  - ../peripherals/exti/exti.yaml

--- a/devices/gd32e231.yaml
+++ b/devices/gd32e231.yaml
@@ -18,3 +18,4 @@ _include:
   - ../peripherals/pmu/pmu.yaml
   - ../peripherals/syscfg/syscfg.yaml
   - ../peripherals/usart/usart.yaml
+  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/gd32e231.yaml
+++ b/devices/gd32e231.yaml
@@ -15,3 +15,4 @@ _include:
   - ../peripherals/gpio/gpio.yaml
   - ../peripherals/i2c/i2c.yaml
   - ../peripherals/i2c/i2c_high.yaml
+  - ../peripherals/pmu/pmu.yaml

--- a/devices/gd32f130.yaml
+++ b/devices/gd32f130.yaml
@@ -18,6 +18,7 @@ _include:
   - ../peripherals/adc/adc_vbat.yaml
   - ../peripherals/crc/crc.yaml
   - ../peripherals/cmp/cmp.yaml
+  - ../peripherals/cmp/cmp_wnd.yaml
   - ../peripherals/dbg/dbg.yaml
   - ../peripherals/dma/dma.yaml
   - ../peripherals/exti/exti.yaml

--- a/devices/gd32f130.yaml
+++ b/devices/gd32f130.yaml
@@ -29,6 +29,7 @@ _include:
   - ../peripherals/i2c/i2c.yaml
   - ../peripherals/ivref/ivref.yaml
   - ../peripherals/pmu/pmu.yaml
+  - ../peripherals/pmu/pmu_wupen1.yaml
   - ../peripherals/rcu/rcu.yaml
   - ../peripherals/rcu/rcu_low.yaml
   - ../peripherals/spi/spi.yaml

--- a/devices/gd32f130.yaml
+++ b/devices/gd32f130.yaml
@@ -15,6 +15,7 @@ _include:
   - common_patches/gd32f1x0.yaml
   - common_patches/gd32f130_150.yaml
   - ../peripherals/adc/adc.yaml
+  - ../peripherals/adc/adc_vbat.yaml
   - ../peripherals/crc/crc.yaml
   - ../peripherals/cmp/cmp.yaml
   - ../peripherals/dbg/dbg.yaml

--- a/devices/gd32f130.yaml
+++ b/devices/gd32f130.yaml
@@ -23,6 +23,7 @@ _include:
   - ../peripherals/dma/dma.yaml
   - ../peripherals/exti/exti.yaml
   - ../peripherals/flash/flash.yaml
+  - ../peripherals/flash/flash_wsen.yaml
   - ../peripherals/fwdgt/fwdgt.yaml
   - ../peripherals/gpio/gpio.yaml
   - ../peripherals/i2c/i2c.yaml

--- a/devices/gd32f130.yaml
+++ b/devices/gd32f130.yaml
@@ -34,6 +34,8 @@ _include:
   - ../peripherals/rcu/rcu_low.yaml
   - ../peripherals/spi/spi.yaml
   - ../peripherals/syscfg/syscfg.yaml
+  - ../peripherals/syscfg/syscfg_hcce.yaml
+  - ../peripherals/syscfg/syscfg_slcd.yaml
   - ../peripherals/timer/timers.yaml
   - ../peripherals/usart/usart.yaml
   - ../peripherals/wwdg/wwdg.yaml

--- a/devices/gd32f130.yaml
+++ b/devices/gd32f130.yaml
@@ -16,9 +16,9 @@ _include:
   - common_patches/gd32f130_150.yaml
   - ../peripherals/adc/adc.yaml
   - ../peripherals/adc/adc_vbat.yaml
-  - ../peripherals/crc/crc.yaml
   - ../peripherals/cmp/cmp.yaml
   - ../peripherals/cmp/cmp_wnd.yaml
+  - ../peripherals/crc/crc.yaml
   - ../peripherals/dbg/dbg.yaml
   - ../peripherals/dma/dma.yaml
   - ../peripherals/exti/exti.yaml

--- a/devices/gd32f150.yaml
+++ b/devices/gd32f150.yaml
@@ -26,9 +26,9 @@ _include:
   - common_patches/gd32f130_150.yaml
   - ../peripherals/adc/adc.yaml
   - ../peripherals/adc/adc_vbat.yaml
-  - ../peripherals/crc/crc.yaml
   - ../peripherals/cmp/cmp.yaml
   - ../peripherals/cmp/cmp_wnd.yaml
+  - ../peripherals/crc/crc.yaml
   - ../peripherals/dac/dac_1ch.yaml
   - ../peripherals/dbg/dbg.yaml
   - ../peripherals/dma/dma.yaml

--- a/devices/gd32f150.yaml
+++ b/devices/gd32f150.yaml
@@ -28,6 +28,7 @@ _include:
   - ../peripherals/adc/adc_vbat.yaml
   - ../peripherals/crc/crc.yaml
   - ../peripherals/cmp/cmp.yaml
+  - ../peripherals/cmp/cmp_wnd.yaml
   - ../peripherals/dac/dac_1ch.yaml
   - ../peripherals/dbg/dbg.yaml
   - ../peripherals/dma/dma.yaml

--- a/devices/gd32f150.yaml
+++ b/devices/gd32f150.yaml
@@ -45,6 +45,8 @@ _include:
   - ../peripherals/rcu/rcu_low.yaml
   - ../peripherals/spi/spi.yaml
   - ../peripherals/syscfg/syscfg.yaml
+  - ../peripherals/syscfg/syscfg_hcce.yaml
+  - ../peripherals/syscfg/syscfg_slcd.yaml
   - ../peripherals/timer/timers.yaml
   - ../peripherals/usart/usart.yaml
   - ../peripherals/wwdg/wwdg.yaml

--- a/devices/gd32f150.yaml
+++ b/devices/gd32f150.yaml
@@ -40,6 +40,7 @@ _include:
   - ../peripherals/i2c/i2c.yaml
   - ../peripherals/ivref/ivref.yaml
   - ../peripherals/pmu/pmu.yaml
+  - ../peripherals/pmu/pmu_wupen1.yaml
   - ../peripherals/rcu/rcu.yaml
   - ../peripherals/rcu/rcu_low.yaml
   - ../peripherals/spi/spi.yaml

--- a/devices/gd32f150.yaml
+++ b/devices/gd32f150.yaml
@@ -34,6 +34,7 @@ _include:
   - ../peripherals/dma/dma.yaml
   - ../peripherals/exti/exti.yaml
   - ../peripherals/flash/flash.yaml
+  - ../peripherals/flash/flash_wsen.yaml
   - ../peripherals/fwdgt/fwdgt.yaml
   - ../peripherals/gpio/gpio.yaml
   - ../peripherals/i2c/i2c.yaml

--- a/devices/gd32f150.yaml
+++ b/devices/gd32f150.yaml
@@ -25,6 +25,7 @@ _include:
   - common_patches/gd32f1x0.yaml
   - common_patches/gd32f130_150.yaml
   - ../peripherals/adc/adc.yaml
+  - ../peripherals/adc/adc_vbat.yaml
   - ../peripherals/crc/crc.yaml
   - ../peripherals/cmp/cmp.yaml
   - ../peripherals/dac/dac_1ch.yaml

--- a/devices/gd32f170.yaml
+++ b/devices/gd32f170.yaml
@@ -14,6 +14,7 @@ _include:
   - common_patches/gd32f1x0.yaml
   - common_patches/gd32f170_190.yaml
   - ../peripherals/adc/adc.yaml
+  - ../peripherals/adc/adc_vbat.yaml
   - ../peripherals/adc/adc_high.yaml
   - ../peripherals/can/can.yaml
   - ../peripherals/crc/crc.yaml

--- a/devices/gd32f170.yaml
+++ b/devices/gd32f170.yaml
@@ -33,6 +33,7 @@ _include:
   - ../peripherals/ivref/ivref.yaml
   - ../peripherals/opa/opa.yaml
   - ../peripherals/pmu/pmu.yaml
+  - ../peripherals/pmu/pmu_wupen1.yaml
   - ../peripherals/rcu/rcu.yaml
   - ../peripherals/rcu/rcu_high.yaml
   - ../peripherals/spi/spi.yaml

--- a/devices/gd32f170.yaml
+++ b/devices/gd32f170.yaml
@@ -25,6 +25,7 @@ _include:
   - ../peripherals/dma/dma.yaml
   - ../peripherals/exti/exti.yaml
   - ../peripherals/flash/flash.yaml
+  - ../peripherals/flash/flash_wsen.yaml
   - ../peripherals/fwdgt/fwdgt.yaml
   - ../peripherals/gpio/gpio.yaml
   - ../peripherals/i2c/i2c.yaml

--- a/devices/gd32f170.yaml
+++ b/devices/gd32f170.yaml
@@ -17,9 +17,9 @@ _include:
   - ../peripherals/adc/adc_vbat.yaml
   - ../peripherals/adc/adc_high.yaml
   - ../peripherals/can/can.yaml
-  - ../peripherals/crc/crc.yaml
   - ../peripherals/cmp/cmp.yaml
   - ../peripherals/cmp/cmp_wnd.yaml
+  - ../peripherals/crc/crc.yaml
   - ../peripherals/dbg/dbg.yaml
   - ../peripherals/dbg/dbg_high.yaml
   - ../peripherals/dma/dma.yaml

--- a/devices/gd32f170.yaml
+++ b/devices/gd32f170.yaml
@@ -19,6 +19,7 @@ _include:
   - ../peripherals/can/can.yaml
   - ../peripherals/crc/crc.yaml
   - ../peripherals/cmp/cmp.yaml
+  - ../peripherals/cmp/cmp_wnd.yaml
   - ../peripherals/dbg/dbg.yaml
   - ../peripherals/dbg/dbg_high.yaml
   - ../peripherals/dma/dma.yaml

--- a/devices/gd32f170.yaml
+++ b/devices/gd32f170.yaml
@@ -39,6 +39,8 @@ _include:
   - ../peripherals/spi/spi.yaml
   - ../peripherals/spi/spi_high.yaml
   - ../peripherals/syscfg/syscfg.yaml
+  - ../peripherals/syscfg/syscfg_hcce.yaml
+  - ../peripherals/syscfg/syscfg_slcd.yaml
   - ../peripherals/timer/timers.yaml
   - ../peripherals/timer/timers_high.yaml
   - ../peripherals/usart/usart.yaml

--- a/devices/gd32f190.yaml
+++ b/devices/gd32f190.yaml
@@ -37,6 +37,8 @@ _include:
   - ../peripherals/spi/spi.yaml
   - ../peripherals/spi/spi_high.yaml
   - ../peripherals/syscfg/syscfg.yaml
+  - ../peripherals/syscfg/syscfg_hcce.yaml
+  - ../peripherals/syscfg/syscfg_slcd.yaml
   - ../peripherals/timer/timers.yaml
   - ../peripherals/timer/timers_high.yaml
   - ../peripherals/usart/usart.yaml

--- a/devices/gd32f190.yaml
+++ b/devices/gd32f190.yaml
@@ -31,6 +31,7 @@ _include:
   - ../peripherals/ivref/ivref.yaml
   - ../peripherals/opa/opa.yaml
   - ../peripherals/pmu/pmu.yaml
+  - ../peripherals/pmu/pmu_wupen1.yaml
   - ../peripherals/rcu/rcu.yaml
   - ../peripherals/rcu/rcu_high.yaml
   - ../peripherals/spi/spi.yaml

--- a/devices/gd32f190.yaml
+++ b/devices/gd32f190.yaml
@@ -23,6 +23,7 @@ _include:
   - ../peripherals/dma/dma.yaml
   - ../peripherals/exti/exti.yaml
   - ../peripherals/flash/flash.yaml
+  - ../peripherals/flash/flash_wsen.yaml
   - ../peripherals/fwdgt/fwdgt.yaml
   - ../peripherals/gpio/gpio.yaml
   - ../peripherals/i2c/i2c.yaml

--- a/devices/gd32f190.yaml
+++ b/devices/gd32f190.yaml
@@ -14,9 +14,9 @@ _include:
   - ../peripherals/adc/adc_vbat.yaml
   - ../peripherals/adc/adc_high.yaml
   - ../peripherals/can/can.yaml
-  - ../peripherals/crc/crc.yaml
   - ../peripherals/cmp/cmp.yaml
   - ../peripherals/cmp/cmp_wnd.yaml
+  - ../peripherals/crc/crc.yaml
   - ../peripherals/dac/dac_2ch.yaml
   - ../peripherals/dbg/dbg.yaml
   - ../peripherals/dbg/dbg_high.yaml

--- a/devices/gd32f190.yaml
+++ b/devices/gd32f190.yaml
@@ -11,6 +11,7 @@ _include:
   - common_patches/gd32f1x0.yaml
   - common_patches/gd32f170_190.yaml
   - ../peripherals/adc/adc.yaml
+  - ../peripherals/adc/adc_vbat.yaml
   - ../peripherals/adc/adc_high.yaml
   - ../peripherals/can/can.yaml
   - ../peripherals/crc/crc.yaml

--- a/devices/gd32f190.yaml
+++ b/devices/gd32f190.yaml
@@ -16,6 +16,7 @@ _include:
   - ../peripherals/can/can.yaml
   - ../peripherals/crc/crc.yaml
   - ../peripherals/cmp/cmp.yaml
+  - ../peripherals/cmp/cmp_wnd.yaml
   - ../peripherals/dac/dac_2ch.yaml
   - ../peripherals/dbg/dbg.yaml
   - ../peripherals/dbg/dbg_high.yaml

--- a/peripherals/adc/adc.yaml
+++ b/peripherals/adc/adc.yaml
@@ -68,9 +68,6 @@ ADC:
       Enabled: [1, "EOC interrupt enabled. An interrupt is generated when the EOC bit is set"]
     WDCHSEL: [0, 18]
   CTL1:
-    VBATEN:
-      Disabled: [0, "VBAT channel disabled"]
-      Enabled: [1, "VBAT channel enabled"]
     TSVREN:
       Disabled: [0, "Channel 16 and 17 disabled"]
       Enabled: [1, "Channel 16 and 17 enabled"]

--- a/peripherals/adc/adc_vbat.yaml
+++ b/peripherals/adc/adc_vbat.yaml
@@ -1,0 +1,9 @@
+# Copyright 2021 The gd32-rs authors.
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+ADC:
+  CTL1:
+    VBATEN:
+      Disabled: [0, "VBAT channel disabled"]
+      Enabled: [1, "VBAT channel enabled"]

--- a/peripherals/cmp/cmp.yaml
+++ b/peripherals/cmp/cmp.yaml
@@ -4,21 +4,21 @@
 
 CMP:
   CS:
-    "CMP?LK":
+    "CMPLK,CMP?LK":
       ReadWrite: [0, "Control bits are read-write"]
       ReadOnly: [1, "Control bits are read-only"]
-    "CMP?O":
+    "CMPO,CMP?O":
       Low: [0, "Non-inverting input below inverting input"]
       High: [1, "Non-inverting input above inverting input"]
-    "CMP?HST":
+    "CMPHST,CMP?HST":
       NoHysteresis: [0, "No hysteresis"]
       LowHysteresis: [1, "Low hysteresis"]
       MediumHysteresis: [2, "Medium hysteresis"]
       HighHysteresis: [3, "High hysteresis"]
-    "CMP?PL":
+    "CMPPL,CMP?PL":
       NotInverted: [0, "Output is not inverted"]
       Inverted: [1, "Output is inverted"]
-    "CMP?OSEL":
+    "CMPOSEL,CMP?OSEL":
       NoSelection: [0, "No selection"]
       Timer0BreakInput: [1, "Timer 0 break input"]
       Timer0InputCapture0: [2, "Timer 0 Input capture 0"]
@@ -27,10 +27,7 @@ CMP:
       Timer1OCPREClearInput: [5, "Timer 1 OCPRE_CLR input"]
       Timer2InputCapture0: [6, "Timer 2 input capture 0"]
       Timer2OCPREClearInput: [7, "Timer 2 OCPRE_CLR input"]
-    WNDEN:
-      Disabled: [0, "Window mode disabled"]
-      Enabled: [1, "Window mode enabled"]
-    "CMP?MSEL":
+    "CMPMSEL,CMP?MSEL":
       OneQuarterVRef: [0, "1/4 of VRefint"]
       OneHalfVRef: [1, "1/2 of VRefint"]
       ThreeQuarterVRef: [2, "3/4 of VRefint"]
@@ -38,14 +35,14 @@ CMP:
       PA4: [4, "PA4 (DAC0"]
       PA5: [5, "PA5"]
       PA0: [6, "PA0"]
-    "CMP?M":
+    "CMPM,CMP?M":
       HighSpeed: [0, "High speed / full power"]
       MediumSpeed: [1, "Medium speed / medium power"]
       LowSpeed: [2, "Low speed / low power"]
       VeryLowSpeed: [3, "Very-low speed / ultra-low power"]
-    "CMP?EN":
+    "CMPEN,CMP?EN":
       Disabled: [0, "Comparator disabled"]
       Enabled: [1, "Comparator enabled"]
-    CMP0SW:
+    "CMPSW,CMP0SW":
       Open: [0, "Switch open"]
       Closed: [1, "Switch closed"]

--- a/peripherals/cmp/cmp_wnd.yaml
+++ b/peripherals/cmp/cmp_wnd.yaml
@@ -1,0 +1,9 @@
+# Copyright 2021 The gd32-rs authors.
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+CMP:
+  CS:
+    WNDEN:
+      Disabled: [0, "Window mode disabled"]
+      Enabled: [1, "Window mode enabled"]

--- a/peripherals/flash/flash.yaml
+++ b/peripherals/flash/flash.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-# Flash memory controller for GD32F devices
+# Flash memory controller
 
 FMC:
   WS:
@@ -85,9 +85,5 @@ FMC:
       Error: [1, "Option bytes and complement bytes do not match"]
   WP:
     OB_WP: [0, 0xFFFF]
-  WSEN:
-    WSEN:
-      NoWaitState: [0, "No wait state added"]
-      WaitState: [1, "Wait state added"]
   PID:
     PID: [0, 0xFFFFFFFF]

--- a/peripherals/flash/flash_wsen.yaml
+++ b/peripherals/flash/flash_wsen.yaml
@@ -1,0 +1,11 @@
+# Copyright 2021 The gd32-rs authors.
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+# Flash memory controller for GD32F devices
+
+FMC:
+  WSEN:
+    WSEN:
+      NoWaitState: [0, "No wait state added"]
+      WaitState: [1, "Wait state added"]

--- a/peripherals/i2c/i2c.yaml
+++ b/peripherals/i2c/i2c.yaml
@@ -14,8 +14,7 @@
       Disabled: [0, "No PEC transfer"]
       Enabled: [1, "PEC transfer"]
     POAP:
-      Current:
-        [0, "ACK bit controls the (N)ACK of the current byte being received"]
+      Current: [0, "ACK bit controls the (N)ACK of the current byte being received"]
       Next: [1, "ACK bit controls the (N)ACK of the next byte to be received"]
     ACKEN:
       NAK: [0, "No acknowledge returned"]
@@ -77,7 +76,7 @@
   DATA:
     TRB: [0, 0xFF]
   STAT0:
-    SMBALTS:
+    SMBALT:
       NoAlert: [0, "SMBA not pulled down or no alert occured"]
       Alert: [1, "SMBA pulled down or alert occurred"]
     SMBTO:
@@ -115,11 +114,7 @@
       Finished: [1, "Data byte transfer successful"]
     ADDSEND:
       NotMatch: [0, "Adress mismatched or not received"]
-      Match:
-        [
-          1,
-          "Received slave address matched with one of the enabled slave addresses",
-        ]
+      Match: [1, "Received slave address matched with one of the enabled slave addresses"]
     SBSEND:
       NoStart: [0, "No Start condition"]
       Start: [1, "Start condition generated"]

--- a/peripherals/pmu/pmu.yaml
+++ b/peripherals/pmu/pmu.yaml
@@ -34,9 +34,6 @@ PMU:
       Normal: [0, "LDO operates normally during Deepsleep mode"]
       LowPower: [1, "LDO in low-power mode during Deepsleep mode"]
   CS:
-    WUPEN1:
-      Disabled: [0, "WKUP pin 1 is used for general purpose I/Os. An event on the WKUP pin 1 does not wakeup the device from Standby mode"]
-      Enabled: [1, "WKUP pin 1 is used for wakeup from Standby mode and forced in input pull down configuration (rising edge on WKUP pin 1 wakes-up the system from Standby mode)"]
     WUPEN0:
       Disabled: [0, "WKUP pin 0 is used for general purpose I/Os. An event on the WKUP pin 0 does not wakeup the device from Standby mode"]
       Enabled: [1, "WKUP pin 0 is used for wakeup from Standby mode and forced in input pull down configuration (rising edge on WKUP pin 0 wakes-up the system from Standby mode)"]

--- a/peripherals/pmu/pmu_wupen1.yaml
+++ b/peripherals/pmu/pmu_wupen1.yaml
@@ -1,0 +1,11 @@
+# Copyright 2021 The gd32-rs authors.
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+# Power controller for GD32F130 and GDF150 devices
+
+PMU:
+  CS:
+    WUPEN1:
+      Disabled: [0, "WKUP pin 1 is used for general purpose I/Os. An event on the WKUP pin 1 does not wakeup the device from Standby mode"]
+      Enabled: [1, "WKUP pin 1 is used for wakeup from Standby mode and forced in input pull down configuration (rising edge on WKUP pin 1 wakes-up the system from Standby mode)"]

--- a/peripherals/syscfg/syscfg.yaml
+++ b/peripherals/syscfg/syscfg.yaml
@@ -4,10 +4,6 @@
 
 SYSCFG:
   CFG0:
-    PB9_HCCE:
-      LowCurrent: [0, "High current capability is disabled"]
-      HighCurrent:
-        [1, "High current capability is enabled, and speed control is bypassed"]
     TIMER16_DMA_RMP:
       Channel0: [0, "Timer 16 DMA requests are mapped to DMA channel 0"]
       Channel1: [1, "Timer 16 DMA requests are remapped to DMA channel 1"]
@@ -27,8 +23,6 @@ SYSCFG:
       Flash: [0, "Boot from main flash"]
       SystemMemory: [1, "Boot from system memory"]
       SRAM: [3, "Boot from embedded SRAM"]
-  CFG1:
-    SLCD_DECA: [0, 7]
   EXTISS0:
     EXTI3_SS:
       PA3: [0, "PA3 pin"]
@@ -115,10 +109,8 @@ SYSCFG:
       Unlocked: [0, "The LVD interrupt is disconnected from the break input"]
       Locked: [1, "The LVD interrupt is connected to the break input"]
     SRAM_PARITY_ERROR_LOCK:
-      Unlocked:
-        [0, "The SRAM parity check error is disconnected from the break input"]
+      Unlocked: [0, "The SRAM parity check error is disconnected from the break input"]
       Locked: [1, "The SRAM parity check error is connected to the break input"]
     LOCKUP_LOCK:
-      Unlocked:
-        [0, "The Cortex-M3 LOCKUP output is disconnected from the break input"]
+      Unlocked: [0, "The Cortex-M3 LOCKUP output is disconnected from the break input"]
       Locked: [1, "The Cortex-M3 LOCKUP output is connected to the break input"]

--- a/peripherals/syscfg/syscfg_hcce.yaml
+++ b/peripherals/syscfg/syscfg_hcce.yaml
@@ -1,0 +1,9 @@
+# Copyright 2021 The gd32-rs authors.
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+SYSCFG:
+  CFG0:
+    PB9_HCCE:
+      LowCurrent: [0, "High current capability is disabled"]
+      HighCurrent: [1, "High current capability is enabled, and speed control is bypassed"]

--- a/peripherals/syscfg/syscfg_slcd.yaml
+++ b/peripherals/syscfg/syscfg_slcd.yaml
@@ -1,0 +1,7 @@
+# Copyright 2021 The gd32-rs authors.
+#
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+SYSCFG:
+  CFG1:
+    SLCD_DECA: [0, 7]


### PR DESCRIPTION
Also renamed some fields to match GD32F1x0 equivalents, and renamed GD32F1x0 `I2Cn.STAT0.SMBALTS` to `SMBALT` to match the documentation and GD32E23x devices.