### PR TITLE
change fmc wsen access to rw

### DIFF
--- a/peripherals/flash/flash_wsen.yaml
+++ b/peripherals/flash/flash_wsen.yaml
@@ -5,6 +5,9 @@
 # Flash memory controller for GD32F devices
 
 FMC:
+  _modify:
+    WSEN:
+      access: read-write
   WSEN:
     WSEN:
       NoWaitState: [0, "No wait state added"]


### PR DESCRIPTION
This register should be writable (according to the reference manual).

I assume patching here is the way to go (instead of changing the svd directly)

related issue: https://github.com/gd32-rust/gd32f1x0-hal/issues/70